### PR TITLE
[Bug]: config.ini doesn't work for some passwords

### DIFF
--- a/python/hello_zilliz_vectordb.py
+++ b/python/hello_zilliz_vectordb.py
@@ -7,7 +7,7 @@ from pymilvus import Collection, DataType, FieldSchema, CollectionSchema
 
 if __name__ == '__main__':
     # connect to milvus
-    cfp = configparser.ConfigParser()
+    cfp = configparser.RawConfigParser()
     cfp.read('config.ini')
     milvus_uri = cfp.get('example', 'uri')
     user = cfp.get('example', 'user')


### PR DESCRIPTION
### Describe the bug
When I update the `config.ini` using some specific password format, the Python code throws an exception. 
- This only happens on some passwords, normal passwords work normally

![image](https://user-images.githubusercontent.com/9654744/236639208-eb8bd76a-7eb5-47b9-ba23-ba1c6ab87b52.png)


### Expected Behavior
The `config.ini` should accept any password string

### Steps/Code To Reproduce Behavior

```markdown
[example]
uri = https://in01-XXXXXX.aws-us-west-2.vectordb.zillizcloud.com:19543
user = u12345
password = YbRg3VE2%F%$F2PUNzR3
secure = True
```

### Solution
Use RawConfigParser instead of ConfigParser to make sure that we can read passwords with special characters

Ref: https://stackoverflow.com/questions/47640354/reading-special-characters-text-from-ini-file-in-python